### PR TITLE
feat: Add message token to return path

### DIFF
--- a/app/senders/smtp_sender.rb
+++ b/app/senders/smtp_sender.rb
@@ -142,10 +142,10 @@ class SMTPSender < BaseSender
     # If the domain has a valid custom return path configured, return
     # that.
     if message.domain.return_path_status == "OK"
-      return "#{message.server.token}@#{message.domain.return_path_domain}"
+      return "#{message.server.token}+#{message.token}@#{message.domain.return_path_domain}"
     end
 
-    "#{message.server.token}@#{Postal::Config.dns.return_path_domain}"
+    "#{message.server.token}+#{message.token}@#{Postal::Config.dns.return_path_domain}"
   end
 
   # Return the RCPT TO to use for the given message in this sending session

--- a/spec/senders/smtp_sender_spec.rb
+++ b/spec/senders/smtp_sender_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe SMTPSender do
             sender.send_message(message)
             expect(sender.endpoints.last).to have_received(:send_message).with(
               kind_of(String),
-              "#{server.token}@#{domain.return_path_domain}",
+              "#{server.token}+#{message.token}@#{domain.return_path_domain}",
               ["john@example.com"]
             )
           end
@@ -272,7 +272,7 @@ RSpec.describe SMTPSender do
             sender.send_message(message)
             expect(sender.endpoints.last).to have_received(:send_message).with(
               kind_of(String),
-              "#{server.token}@#{Postal::Config.dns.return_path_domain}",
+              "#{server.token}+#{message.token}@#{Postal::Config.dns.return_path_domain}",
               ["john@example.com"]
             )
           end
@@ -306,7 +306,7 @@ RSpec.describe SMTPSender do
           it "adds the resent-sender header" do
             sender.send_message(message)
             expect(sender.endpoints.last).to have_received(:send_message).with(
-              "Resent-Sender: #{server.token}@#{Postal::Config.dns.return_path_domain}\r\n#{message.raw_message}",
+              "Resent-Sender: #{server.token}+#{message.token}@#{Postal::Config.dns.return_path_domain}\r\n#{message.raw_message}",
               kind_of(String),
               kind_of(Array)
             )


### PR DESCRIPTION
* feat: Add message token to return path

Adding the message token to the return path would be beneficial for users to link bounces to email addresses when X-Postal-MsgID was not included in the bounce message's headers.



* test: update smtp_sender_spect.rb to reflect design changes to mail from



---------